### PR TITLE
Add argparse-based converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # sintaxes_deliciosas
 corretor supremo de programas, funções, aprimoramentos e sinteaxes no geral
+
+## converter.py
+
+Combine vários arquivos de texto em um único arquivo.
+
+```bash
+python3 converter.py arquivo1.txt arquivo2.txt arquivo3.txt -o resultado.txt
+```
+
+Se a opção `-o` não for especificada, o resultado será salvo em `merged.txt`.

--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Merge multiple text files into a single output file."""
+
+import argparse
+from pathlib import Path
+
+
+def merge_files(input_files: list[str], output_file: Path) -> None:
+    """Merge the contents of *input_files* into *output_file*."""
+    with output_file.open('w', encoding='utf-8') as dest:
+        for index, name in enumerate(input_files):
+            path = Path(name)
+            with path.open('r', encoding='utf-8') as src:
+                dest.write(src.read())
+            if index < len(input_files) - 1:
+                dest.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Merge multiple text files into one file.")
+    parser.add_argument(
+        'files', nargs='+', help='Input files to merge')
+    parser.add_argument(
+        '-o', '--output', default='merged.txt', help='Output filename')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    merge_files(args.files, Path(args.output))
+    print(f"Merged {len(args.files)} files into '{args.output}'.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `converter.py` for merging text files using `argparse`
- support multiple input files and optional `-o/--output` argument
- document converter usage in README

## Testing
- `python3 -m py_compile converter.py`
